### PR TITLE
Automatic Chat Templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 > Isn't it cool to utilize large language model (LLM) to generate contents for your game?
 - @Adriankhl, original creator of GDLlama
 
-Why, yes, I do think it is cool! The generative space is an exciting frontier for video games that has been sorely under-explored so far. LLMs and multimodal models have a great potential to complement multiple aspects of game design, from dialogue generation to quest generation and beyond. Thanks to `llama.cpp`, we can perform inference fast enough locally to enable some genuinely interesting gameplay. I want Godot to be at the forefront of that, or at least keeping pace with Unity and Unreal.
+Why, yes, I do think it is cool! The generative space is an exciting frontier for video games that has been sorely under-explored so far. LLMs and multimodal models have a great potential to complement multiple aspects of game design, from dialogue generation to quest generation and beyond. Thanks to `llama.cpp`, we can perform inference fast enough locally to enable some genuinely interesting gameplay. I want to help Godot at least keep pace with Unity and Unreal.
 
-I intend to maintain this for an indefinite amount of time while it continues to be useful to me. This is a fork of [Adriankhl's original godot-llm](https://github.com/Adriankhl/godot-llm) with updated build instructions and fixes for recent `llama.cpp` versions. It has been almost entirely re-written.
+I intend to maintain this for an indefinite amount of time while it continues to be useful to me. This is a fork of [Adriankhl's original godot-llm](https://github.com/Adriankhl/godot-llm) with updated build instructions and fixes for recent `llama.cpp` versions. It has been almost entirely re-written with a number of new features. It is notable that, at the moment, I do not know the state of embeddings or the DB functionality. I intend to resolve these issues before a full release to the Godot Asset Shop. For progress, see: https://github.com/xarillian/GDLlama/milestone/1
 
 # Getting Started
 For now, everything has to be built by the user. GDLlama is not yet in the asset library, no sir. I'd like a bit more polish on the project before getting to a 1.0 release state where I'd put it in the library.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,7 +1,13 @@
 # API
-The `GDLlama` node is a new node in Godot that acts as a bridge to the `llama.cpp` library, allowing you to perform complex AI text generation tasks directly from GDScript without halting your game.
+The `GDLlama` node is a custom Godot node that acts as a bridge to the `llama.cpp` library, allowing you to perform complex AI text generation tasks directly from GDScript or C# without halting your game. Key features include:
 
-To use it, add a GDLlama node to your scene from the "Add Child Node" dialog. You can then give the node any unique name and access it from your scripts like any other node.
+- Conversational AI: Maintain context between calls to create multi-turn chatbots.
+- Non-conversational Responses: One-shot generation for single use text generation.
+- Real-time Streaming: Receive text as it's being generated using signals.
+- Flexible Generation: Perform both synchronous and asynchronous text generation.
+- Model Management: Load and unload .gguf model files at runtime.
+
+To use it, add a `GDLlama` node to your scene from the "Add Child Node" dialog. You can then give the node any unique name and access it from your scripts like any other node.
 
 Getting started:
 1) Add a `GDLlama` node to your scene.
@@ -19,21 +25,22 @@ These properties belong to a `GDLlama` node and can be set via code or the Godot
 | `n_predict` | `int` | `-1` to context size defined on the model | The maximum number of new tokens the model should generate in a single run. `-1` specifies generation until an EOS token is found or the context is full. |
 | `temperature` | `float` | `0.0` to `2.0` | Controls randomness. Higher values (e.g., `1.0`) make the output more random or potentially creative; lower values (e.g., `0.1`) make it more focused and deterministic. |
 | `top_k` | `int` | `0` to vocab size | Reduces the pool of tokens to the `k` most likely ones (`0` = disabled). A lower value (e.g., `40`) can prevent strange tokens from appearing. |
-| `top_p` | `float` | `0.0` to `1.0` | Nucleous sampling. It considers the smallest set of tokens whose cumulative probability exceeds `p`. A value of `0.9` is a good starting point. |
+| `top_p` | `float` | `0.0` to `1.0` | Nucleus sampling. It considers the smallest set of tokens whose cumulative probability exceeds `p`. A value of `0.9` is a good starting point. |
 | `ignore_eos` | `bool` | `true`/`false` | If `true`, the model will not stop when it generates an End-of-Sequence token. |
 | `penalty_repeat` | `float` | `1.0` to `2.0` | Penalizes the model for repeating tokens it has recently used (`1.0` = no penalty). |
 | `penalty_last_n` | `int` | `0` to context size | The number of recent tokens to consider for the repetition penalty (`0` = disabled). |
+| `chat_template` | `string` | N/A | A custom chat template in Jinja2 format. If empty (default), the model's built-in chat template is used automatically. This is an advanced feature for supporting models with non-standard prompt formats or for models with incorrect metadata (or doing weird things). |
 
 The default values for these properties are provided by `llama.cpp`, as defined by the `common_params_sampling` struct. See: https://github.com/ggml-org/llama.cpp/blob/3d4053f77f0f78ee2b791088c02af653ebee42dd/common/common.h#L137
 
 ## Access Methods
 | Method | Description |
 |---|---|
-| `load_model() -> Error` | Loads the model specified by the `model_path` property into memory. Must be called before any generation can occurs. **The user is responsible for managing their model in memory!** Returns `@GlobalScope.OK` on success. |
+| `load_model() -> Error` | Loads the model specified by the `model_path` property into memory. Must be called before any generation can occur. **The user is responsible for managing their model in memory!** Returns `@GlobalScope.OK` on success. |
 | `unload_model() -> void` | Unloads the currently loaded model from memory, freeing resources. |
 | `is_model_loaded() -> bool` | Returns `true` if a model is currently loaded and ready for use, `false` otherwise. |
-| `generate_text(prompt: String, grammar: String = "", json: String = "") -> String` | Performs a synchronous (blocking) text generation. This method always starts with a fresh context. |
-| `generate_text_async(prompt: String, grammar: String = "", json: String = "") -> Error` | Starts an asynchronous (non-blocking) generation. The result is delivered via the `generate_text_finished` signal. Returns `@GlobalScope.OK` on success or `@GlobalScope.FAILED` if another async task is already running. |
+| `generate_text(prompt: String, grammar: String = "", json: String = "") -> String` | Performs a synchronous (blocking) text generation. This method always starts with a fresh context and applies no text formatting. |
+| `generate_text_async(prompt: String, grammar: String = "", json: String = "") -> Error` | Starts an asynchronous (non-blocking) generation. The result is delivered via the `generate_text_finished` signal. Returns `@GlobalScope.OK` on success or `@GlobalScope.FAILED` if another async task is already running. This method always starts with a fresh context and applies no text formatting. |
 | `generate_chat(prompt: String, grammar: String = "", json: String = "") -> String` | A synchronous (blocking) method that maintains conversational context between calls. Used for multi-turn conversations. |
 | `generate_chat_async(prompt: String, grammar: String = "", json: String = "") -> Error` | The asynchronous (non-blocking) version of generate_chat. Maintains context and delivers the result via a signal. |
 | `stop_generate_text() -> void` | Sends a stop signal to the currently running asynchronous generation. The generation will finish its current token and then stop gracefully. |
@@ -48,13 +55,17 @@ The default values for these properties are provided by `llama.cpp`, as defined 
 | `generate_text_error` | `error_text: String` | Emitted once when async generation has completed with an error. |
 
 ## Example Godot Usage
-```
+```gdscript
 @onready var llm: GDLlama = $GDLlama   # a reference to the GDLlama Node
+var full_response: String = ""         # a variable to store the response as it streams in
 
 func _ready():
     # Connect to the signals to receive results from async calls
     llm.generate_text_updated.connect(_on_text_updated)
     llm.generate_text_finished.connect(_on_text_finished)
+
+    # Configure the model path to wherever you have your llama-compatible model stored
+    llm.model_path = "res://models/your_model.gguf"
 
     # Load the model before doing anything else
     if not llm.is_model_loaded():
@@ -66,9 +77,23 @@ func _ready():
     var prompt = "Tell me a story about the river of Saskatoon."
     llm.generate_text_async(prompt)
 
-func _on_text_updated(text: String):
-    prints(text)
+    # Here, for example purposes, we wait for the generation to complete.
+    # This makes this part of the function "block" while allowing the game to remain responsive.
+    # In a real game, you might not await here, and instead let the signal handlers
+    # do their work whenever they are called.
+    await llm.generate_text_finished
 
-func _on_text_finished(text: String):
-    print(text)
+    # Finally, it is best practice to unload the model from memory when you are done with it
+    llm.unload_model()
+
+func _on_text_updated(new_text: String):
+    # This example function is for STREAMING. It is called repeatedly with new text chunks because
+    # we hooked it up to our `generate_text_updated` signal.
+    full_response += new_text
+    prints(new_text)
+
+func _on_text_finished(full_text: String):
+    # This example function is for COMPLETION. It is called once when the entire generation is 
+    # finished because we hooked it up to our `generate_text_finished` signal
+    print(full_text)
 ```

--- a/include/gdllama.hpp
+++ b/include/gdllama.hpp
@@ -60,6 +60,9 @@ class GDLlama : public Node {
         void set_penalty_last_n(int p_penalty_last_n);
         int get_penalty_last_n() const;
 
+        void set_chat_template(const String &p_chat_template);
+        String get_chat_template() const;
+
     protected:
         static void _bind_methods();
 

--- a/include/llama_controller.hpp
+++ b/include/llama_controller.hpp
@@ -10,6 +10,17 @@
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/classes/global_constants.hpp>
 
+/**
+ * @brief A C++ representation of a single chat message.
+ *
+ * This struct mirrors the C-style `llama_chat_message` but uses `std::string`
+ * to ensure safe, automatic memory management of the role and content text.
+ */
+struct ChatMessage {
+    std::string role;
+    std::string content;
+};
+
 class LlamaController {
     public:
         LlamaController();
@@ -20,7 +31,7 @@ class LlamaController {
          * @param prompt The user's input prompt.
          * @param grammar Optional BNF grammar string to constrain generation. Empty string for no grammar.         
          * @param json Optional JSON schema to constrain generation. Will be converted to grammar
-    *  *               internally. If both grammar and JSON are provided, grammar takes precedence.
+         *             internally. If both grammar and JSON are provided, grammar takes precedence.
          * @param on_update Callback for streaming text chunks.
          * @param on_finish Callback for when generation is complete.
          * @return The complete generated text.
@@ -44,6 +55,7 @@ class LlamaController {
     private:
         std::unique_ptr<LlamaState> llama_state;
         std::unique_ptr<LlamaRunner> llama_runner;
+        std::vector<ChatMessage> conversation_history;
 
 };
 

--- a/src/gdllama.cpp
+++ b/src/gdllama.cpp
@@ -42,6 +42,7 @@ namespace godot {
         BIND_GDL_PROPERTY(ignore_eos, Variant::BOOL);
         BIND_GDL_PROPERTY(penalty_repeat, Variant::FLOAT);
         BIND_GDL_PROPERTY(penalty_last_n, Variant::INT);
+        BIND_GDL_PROPERTY(chat_template, Variant::STRING);
 
         // ## State Checking ##
         ClassDB::bind_method(D_METHOD("is_running"), &GDLlama::is_running);
@@ -302,5 +303,15 @@ namespace godot {
     int GDLlama::get_penalty_last_n() const {
         godot::MutexLock lock(*(generation_mutex.ptr()));
         return params.sampling.penalty_last_n;
+    }
+
+    void GDLlama::set_chat_template(const String &p_chat_template) {
+        godot::MutexLock lock(*(generation_mutex.ptr()));
+        params.chat_template = string_gd_to_std(p_chat_template);
+    }
+
+    String GDLlama::get_chat_template() const {
+        godot::MutexLock lock(*(generation_mutex.ptr()));
+        return string_std_to_gd(params.chat_template);
     }
 }  // namespace godot

--- a/src/llama_controller.cpp
+++ b/src/llama_controller.cpp
@@ -22,11 +22,45 @@ std::string LlamaController::start_generation(
         throw std::runtime_error(err_msg);
     }
 
-    if (!is_continuous) {
+    if (is_continuous) {
+        conversation_history.push_back({"user", prompt});
+
+        std::vector<llama_chat_message> messages_for_api;
+        for (const auto& msg : conversation_history) {
+            messages_for_api.push_back({msg.role.c_str(), msg.content.c_str()});
+        }
+
+        const int32_t buffer_size = llama_n_ctx(llama_state->get_context());
+        std::vector<char> buffer(buffer_size);
+
+        int32_t formatted_size = llama_chat_apply_template(
+            params.chat_template.empty() ? nullptr : params.chat_template.c_str(),
+            messages_for_api.data(),
+            messages_for_api.size(),
+            true, // add_assistant_prefix
+            buffer.data(),
+            buffer.size()
+        );
+        
+        if (formatted_size < 0) {
+            conversation_history.pop_back();
+            throw std::runtime_error("Failed to apply chat template.");
+        }
+
+        if (static_cast<int32_t>(buffer.size()) <= formatted_size) {
+            conversation_history.pop_back();
+            throw std::runtime_error("Formatted chat prompt exceeds the buffer size.");
+        }
+
+        params.prompt = std::string(buffer.data());
+    } else {
+        // For non-continuous (single-shot) generation, we don't apply a chat
+        // template. This mode is for raw text completion, and applying chat
+        // formatting would be incorrect.
         reset_context();
+        params.prompt = prompt;
     }
 
-    params.prompt = prompt;
     if (!grammar.empty()) {
         params.sampling.grammar = grammar;
     } else if (!json.empty()) {
@@ -37,6 +71,10 @@ std::string LlamaController::start_generation(
     llama_model* model = llama_state->get_model();
 
     std::string generated_text = llama_runner->run_prediction(model, ctx, params, on_update);
+
+    if (is_continuous && !generated_text.empty()) {
+        conversation_history.push_back({ "assistant", generated_text.c_str() });
+    }
 
     params.sampling.grammar.clear();
 
@@ -58,6 +96,7 @@ void LlamaController::reset_context() {
         llama_memory_clear(llama_get_memory(llama_state->get_context()), true);
         GDLOG_DEBUG("LLM context (KV cache) cleared.");
     }
+    conversation_history.clear();
 }
 
 godot::Error LlamaController::load_model(common_params& params) {
@@ -72,5 +111,8 @@ godot::Error LlamaController::load_model(common_params& params) {
 }
 
 void LlamaController::unload_model() {
+    reset_context();
+    GDLOG_DEBUG("Chat history cleared on model unload.");
     llama_state->unload();
+    GDLOG_DEBUG("Model unloaded.");
 }


### PR DESCRIPTION
Resolves #21 

Adds automatic chat templates for llama-compatible models.

Provides a `chat_template` property for cases where a user's model's metadata is incorrect, as it was for my test model, or the user desires to chat the chat template.