### PR TITLE
Automatic build against llama.cpp gives fatal: Need to specify how to reconcile divergent branches.

### DIFF
--- a/.github/workflows/build-with-latest-llama-.yml
+++ b/.github/workflows/build-with-latest-llama-.yml
@@ -1,4 +1,5 @@
 name: Build with Latest Llama
+description: The "oh my god, it broke again" workflow
 
 on:
   schedule:
@@ -18,7 +19,8 @@ jobs:
     - name: Update llama.cpp to latest
       run: |
         cd llama.cpp
-        git pull origin master
+        git fetch
+        git reset --hard origin/master
 
     - name: Configure and Build
       run: |


### PR DESCRIPTION
Resolves #13 

Does a git reset. Hard.

Probably works.

Also updates `llama.cpp` to the latest version of master, because why not.

