### PR TITLE
Regress Godot version to ~~4.0~~ 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 build/
 bulid_release/
 install/
+
+/tests/models/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 > Isn't it cool to utilize large language model (LLM) to generate contents for your game?
 - @Adriankhl, original creator of GDLlama
 
-Why, yes, I do think it is cool! The generative space is an exciting frontier for video games that has been sorely under-explored so far. LLMs and multimodal models have a great potential to complement multiple aspects of game design, from dialogue generation to quest generation and beyond. Thanks to `llama.cpp`, we can perform inference fast enough locally to enable some genuinely interesting gameplay. I want to help Godot at least keep pace with Unity and Unreal.
+Why, yes, I do think it is cool! 
 
-I intend to maintain this for an indefinite amount of time while it continues to be useful to me. This is a fork of [Adriankhl's original godot-llm](https://github.com/Adriankhl/godot-llm) with updated build instructions and fixes for recent `llama.cpp` versions. It has been almost entirely re-written with a number of new features. For a full release, I intend to publish this to the Godot Asset Shop. For progress, see: https://github.com/xarillian/GDLlama/milestone/1
-
-## What is GDLlama?
-`GDLlama` is a GDExtension for Godot 4.0+ that acts as a bridge to the powerful `llama.cpp` library. This allows you to perform fast, local inference with Large Language Models (LLMs) directly in your game, without needing an internet connection or external servers.
+`GDLlama` is a GDExtension for Godot 4.2+ that acts as a bridge to the powerful `llama.cpp` library. This allows you to perform fast, local inference with Large Language Models (LLMs) directly in your game, without needing an internet connection or external servers.
 
 It's implemented as a custom GDLlama node that you can add to any scene, making generative AI a native part of your project. It's designed to be flexible and powerful, supporting key features like:
 - Conversational AI: Maintain context between calls to create multi-turn chatbots.
@@ -15,6 +12,10 @@ It's implemented as a custom GDLlama node that you can add to any scene, making 
 - Real-time Streaming: Receive text as it's being generated using signals.
 - Flexible Generation: Perform both synchronous and asynchronous text generation.
 - Embeddings: Enable features like semantic search and content similarity checks.
+
+The generative space is an exciting frontier for video games that has been sorely under-explored so far. LLMs and multimodal models have a great potential to complement multiple aspects of game design, from dialogue generation to quest generation and beyond. Thanks to `llama.cpp`, we can perform inference fast enough locally to enable some genuinely interesting gameplay. I want to help Godot at least keep pace with Unity and Unreal.
+
+I intend to maintain this for an indefinite amount of time while it continues to be useful to me. This is a fork of [Adriankhl's original godot-llm](https://github.com/Adriankhl/godot-llm) with updated build instructions and fixes for recent `llama.cpp` versions. It has been almost entirely re-written with a number of new features. For a full release, I intend to publish this to the Godot Asset Shop. For progress, see: https://github.com/xarillian/GDLlama/milestone/1
 
 # Getting Started
 For now, everything has to be built by the user. GDLlama is not yet in the asset library, no sir. I'd like a bit more polish on the project before getting to a 1.0 release state where I'd put it in the library.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -15,11 +15,26 @@
 git clone https://github.com/xarillian/GDLlama.git
 cd godot-llm
 git submodule update --init --recursive
+```
+
+2. Generate the necessary Godot bindings. 
+
+```shell
+cd godot-cpp
+scons generate_bindings=True
+cd ..
+```
+
+Godot recommends scons for building and has an SConstruct.  
+
+3. Run `cmake`.
+
+First, create a build dir and move into it.
+
+```shell
 mkdir build
 cd build
 ```
-
-2. Run `cmake`.
 
 ### Windows
 from preset (recommended):
@@ -46,14 +61,14 @@ For Android, set `$NDK_PATH` to your android ndk directory, then:
 cmake .. -GNinja -DCMAKE_TOOLCHAIN_FILE=$NDK_PATH\cmake\android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-23 -DCMAKE_C_FLAGS="-mcpu=generic" -DCMAKE_CXX_FLAGS="-mcpu=generic" -DCMAKE_BUILD_TYPE=Release
 ```
 
-3. Compile and install with `ninja`.
+4. Compile and install with `ninja`.
 
 ```shell
 ninja
 ninja install
 ```
 
-4. The folder `godot-llm/install/gpu/addons/godot_llm` can be copied to the `addons` folder of your Godot project. On Windows at least, you will also need to copy the required DLL dependencies from `godot-llm/install/bin` into your Godot project's `addons/godot_llm/bin/` directory:
+5. The folder `godot-llm/install/gpu/addons/godot_llm` can be copied to the `addons` folder of your Godot project. On Windows at least, you will also need to copy the required DLL dependencies from `godot-llm/install/bin` into your Godot project's `addons/godot_llm/bin/` directory:
 - `ggml.dll`
 - `ggml-base.dll`
 - `ggml-cpu.dll`


### PR DESCRIPTION
Resolves #47 

It turns out we were already on 4.2.2 which I think is sufficient.

Updated some docs