### PR TITLE
Fix issues with Infinite Generation and leaky abstraction in llama_controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches: [ master ]
-  pull_request: # test!
+  pull_request:
     branches: [ master ] 
   workflow_dispatch:
 

--- a/include/common_types.hpp
+++ b/include/common_types.hpp
@@ -1,4 +1,8 @@
+#ifndef COMMON_TYPES_HPP
+#define COMMON_TYPES_HPP
+
 #include <string>
+#include <vector>
 
 /**
  * @brief A C++ representation of a single chat message.
@@ -10,3 +14,5 @@ struct ChatMessage {
     std::string role;
     std::string content;
 };
+
+#endif // COMMON_TYPES_HPP

--- a/include/common_types.hpp
+++ b/include/common_types.hpp
@@ -1,0 +1,12 @@
+#include <string>
+
+/**
+ * @brief A C++ representation of a single chat message.
+ *
+ * This struct mirrors the C-style `llama_chat_message` but uses `std::string`
+ * to ensure safe, automatic memory management of the role and content text.
+ */
+struct ChatMessage {
+    std::string role;
+    std::string content;
+};

--- a/include/gdllama.hpp
+++ b/include/gdllama.hpp
@@ -100,7 +100,7 @@ class GDLlama : public Node {
             godot::String prompt,
             godot::String grammar,
             godot::String json,
-            bool is_continuous,
+            bool is_conversational,
             std::string* error_msg = nullptr
         );
 
@@ -120,7 +120,7 @@ class GDLlama : public Node {
             godot::String prompt,
             godot::String grammar,
             godot::String json,
-            bool is_continuous
+            bool is_conversational
         );
         void _embedding_task(String prompt);
 

--- a/include/llama_controller.hpp
+++ b/include/llama_controller.hpp
@@ -4,22 +4,12 @@
 #include "llama_state.hpp"
 #include "llama_runner.hpp"
 #include "logging_utils.hpp"
+#include "common_types.hpp"
 #include <mutex>
 #include <functional>
 #include <common.h>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/classes/global_constants.hpp>
-
-/**
- * @brief A C++ representation of a single chat message.
- *
- * This struct mirrors the C-style `llama_chat_message` but uses `std::string`
- * to ensure safe, automatic memory management of the role and content text.
- */
-struct ChatMessage {
-    std::string role;
-    std::string content;
-};
 
 class LlamaController {
     public:
@@ -42,7 +32,7 @@ class LlamaController {
             const std::string& prompt,
             const std::string& grammar,
             const std::string& json,
-            bool is_continuous,
+            bool is_conversational,
             std::function<void(std::string)> on_update,
             std::string* error_msg = nullptr
         );

--- a/include/llama_runner.hpp
+++ b/include/llama_runner.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <functional>
 #include <string>
+#include "common_types.hpp"
 
 /**
  * @class LlamaRunner
@@ -22,6 +23,7 @@ class LlamaRunner {
          * @param model A pointer to the loaded llama_model.
          * @param ctx A pointer to the active llama_context.
          * @param params The common_params struct for this generation task.
+         * @param conversation_history A pointer to the conversation history vector.
          * @param on_generate_text_updated Callback for streaming text chunks.
          * @param error_msg Optional output parameter for error messages.
          * @return The complete generated text string.
@@ -30,6 +32,7 @@ class LlamaRunner {
             llama_model* model,
             llama_context* ctx,
             common_params& params,
+            const std::vector<ChatMessage>* conversation_history,
             std::function<void(std::string)> on_generate_text_updated,
             std::string* error_msg = nullptr
         );

--- a/src/gdllama.cpp
+++ b/src/gdllama.cpp
@@ -49,7 +49,7 @@ namespace godot {
         String prompt,
         String grammar,
         String json,
-        bool is_continuous,
+        bool is_conversational,
         std::string* error_msg
     ) {
         auto on_update = [this](const std::string& text_chunk) {
@@ -66,7 +66,7 @@ namespace godot {
             s_prompt, 
             s_grammar,
             s_json,
-            is_continuous,
+            is_conversational,
             on_update,
             &internal_error
         );
@@ -123,10 +123,10 @@ namespace godot {
         return generate_text_thread->start(callable);
     }
 
-    void GDLlama::_generation_task(String prompt, String grammar, String json, bool is_continuous) {
+    void GDLlama::_generation_task(String prompt, String grammar, String json, bool is_conversational) {
         godot::MutexLock lock(*(generation_mutex.ptr()));
         std::string error_msg;
-        String result = _generate(prompt, grammar, json, is_continuous, &error_msg);
+        String result = _generate(prompt, grammar, json, is_conversational, &error_msg);
     
         if (!error_msg.empty()) {
             callable_mp(this, &GDLlama::_on_generate_text_error).call_deferred(string_std_to_gd(error_msg));

--- a/src/llama_controller.cpp
+++ b/src/llama_controller.cpp
@@ -11,7 +11,7 @@ std::string LlamaController::start_generation(
     const std::string& prompt,
     const std::string& grammar,
     const std::string& json,
-    bool is_continuous,
+    bool is_conversational,
     std::function<void(std::string)> on_update,
     std::string* error_msg
 ) {
@@ -23,47 +23,9 @@ std::string LlamaController::start_generation(
         return "";
     }
 
-    if (is_continuous) {
+    if (is_conversational) {
         conversation_history.push_back({"user", prompt});
-
-        std::vector<llama_chat_message> messages_for_api;
-        for (const auto& msg : conversation_history) {
-            messages_for_api.push_back({msg.role.c_str(), msg.content.c_str()});
-        }
-
-        const int32_t buffer_size = llama_n_ctx(llama_state->get_context());
-        std::vector<char> buffer(buffer_size);
-
-        int32_t formatted_size = llama_chat_apply_template(
-            params.chat_template.empty() ? nullptr : params.chat_template.c_str(),
-            messages_for_api.data(),
-            messages_for_api.size(),
-            true, // add_assistant_prefix
-            buffer.data(),
-            buffer.size()
-        );
-        
-        if (formatted_size < 0) {
-            conversation_history.pop_back();
-            std::string err = "Failed to apply chat template.";
-            GDLOG_ERROR(err);
-            if (error_msg) *error_msg = err;
-            return "";
-        }
-
-        if (static_cast<int32_t>(buffer.size()) <= formatted_size) {
-            conversation_history.pop_back();
-            std::string err = "Formatted chat prompt exceeds the buffer size.";
-            GDLOG_ERROR(err);
-            if (error_msg) *error_msg = err;
-            return "";
-        }
-
-        params.prompt = std::string(buffer.data());
     } else {
-        // For non-continuous (single-shot) generation, we don't apply a chat
-        // template. This mode is for raw text completion, and applying chat
-        // formatting not supplied by the user would be incorrect.
         reset_context();
         params.prompt = prompt;
     }
@@ -77,13 +39,20 @@ std::string LlamaController::start_generation(
     llama_context* ctx = llama_state->get_context();
     llama_model* model = llama_state->get_model();
 
-    std::string generated_text = llama_runner->run_prediction(model, ctx, params, on_update, error_msg);
+    std::string generated_text = llama_runner->run_prediction(
+        model, 
+        ctx, 
+        params,
+        is_conversational ? &conversation_history : nullptr,
+        on_update,
+        error_msg
+    );
 
     if (error_msg && !error_msg->empty()) {
         return "";  // Error occurred in runner
     }
 
-    if (is_continuous) {
+    if (is_conversational) {
         // We specifically add empty assistant messages to the history here.
         // These could be ignored, but it's useful to see where the model responded
         // in the conversation.

--- a/src/llama_runner.cpp
+++ b/src/llama_runner.cpp
@@ -35,10 +35,51 @@ bool LlamaRunner::decode_with_error_handling(
     return true;
 }
 
+std::string apply_chat_template(
+    llama_context* ctx,
+    const std::vector<ChatMessage>& conversation_history,
+    const std::string& chat_template,
+    std::string* error_msg
+) {
+    std::vector<llama_chat_message> messages_for_api;
+    for (const auto& msg : conversation_history) {
+        messages_for_api.push_back({msg.role.c_str(), msg.content.c_str()});
+    }
+
+    const int32_t buffer_size = llama_n_ctx(ctx);
+    std::vector<char> buffer(buffer_size);
+
+    int32_t formatted_size = llama_chat_apply_template(
+        chat_template.empty() ? nullptr : chat_template.c_str(),
+        messages_for_api.data(),
+        messages_for_api.size(),
+        true, // add_assistant_prefix
+        buffer.data(),
+        buffer.size()
+    );
+    
+    if (formatted_size < 0) {
+        std::string err = "Failed to apply chat template.";
+        GDLOG_ERROR(err);
+        if (error_msg) *error_msg = err;
+        return "";
+    }
+
+    if (static_cast<int32_t>(buffer.size()) <= formatted_size) {
+        std::string err = "Formatted chat prompt exceeds the buffer size.";
+        GDLOG_ERROR(err);
+        if (error_msg) *error_msg = err;
+        return "";
+    }
+
+    return std::string(buffer.data());
+}
+
 std::string LlamaRunner::run_prediction(
     llama_model* model,
     llama_context* ctx,
     common_params& params,
+    const std::vector<ChatMessage>* conversation_history,
     std::function<void(std::string)> on_generate_text_updated,
     std::string* error_msg
 ){
@@ -55,6 +96,17 @@ std::string LlamaRunner::run_prediction(
         GDLOG_ERROR(err_msg);
         if (error_msg) *error_msg = err_msg;
         return "";
+    }
+
+    if (conversation_history != nullptr) {
+        std::string formatted_prompt = apply_chat_template(
+            ctx,
+            *conversation_history,
+            params.chat_template,
+            error_msg
+        );
+
+        params.prompt = formatted_prompt;
     }
 
     const bool add_bos = llama_vocab_get_add_bos(llama_model_get_vocab(model));
@@ -95,12 +147,12 @@ std::string LlamaRunner::run_prediction(
     const llama_pos max_pos = llama_memory_seq_pos_max(llama_get_memory(ctx), 0);
     int n_past = (max_pos == -1) ? 0 : max_pos + 1;
     const auto * vocab = llama_model_get_vocab(model);
-        
+ 
     const llama_token EOD_TOKEN = llama_vocab_eos(vocab);
 
     GDLOG_DEBUG("Starting Generation Loop.");
     GDLOG_DEBUG("n_remain: " + std::to_string(n_remain));
-    while (n_remain > 0 && !should_stop_generation) {
+    while ((params.n_predict == -1 || n_remain > 0) && !should_stop_generation) {
         if (n_past < prompt_tokens.size()) {
             embd.clear();
             int n_eval = (int)prompt_tokens.size() - n_past;
@@ -109,7 +161,7 @@ std::string LlamaRunner::run_prediction(
                 embd.push_back(prompt_tokens[n_past + i]);
             }
         }
-        
+
         if (!embd.empty()) {
             if (n_past + (int)embd.size() > n_ctx) {
                 GDLOG_WARN("Context window is full, stopping generation.");
@@ -145,7 +197,9 @@ std::string LlamaRunner::run_prediction(
             on_generate_text_updated(token_str);
             generated_text.append(token_str);
 
-            n_remain--;
+            if (params.n_predict != -1) {
+                n_remain--;
+            }
 
             embd.clear();
             embd.push_back(new_token_id);

--- a/tests/test_llama_controller.cpp
+++ b/tests/test_llama_controller.cpp
@@ -25,7 +25,7 @@ TEST_F(LlamaControllerTest, GenerateReturnsErrorWhenModelNotLoaded) {
 
     std::string error_msg;
     std::string result = controller->start_generation(
-        params, "test prompt", "", "", false, 
+        params, "test prompt", "", "", false,  // is_conversational = false
         [](const std::string& chunk) {},
         &error_msg
     );
@@ -55,7 +55,7 @@ TEST_F(LlamaControllerTest, ResetContextClearsConversationHistory) {
     
     std::string error_msg;
     std::string response1 = controller->start_generation(
-        params, "Hello!", "", "", true, // is_continuous = true
+        params, "Hello!", "", "", true, // is_conversational = true
         [](const std::string& chunk) {},
         &error_msg
     );
@@ -76,11 +76,90 @@ TEST_F(LlamaControllerTest, SuccessfulGenerationHasNoError) {
     params.n_predict = 10;
     
     std::string result = controller->start_generation(
-        params, "Say hello", "", "", false,
+        params, "Say hello", "", "", false,  // is_conversational = false
         [](const std::string& chunk) {},
         &error_msg
     );
 
     ASSERT_TRUE(error_msg.empty());
     ASSERT_FALSE(result.empty());
+}
+
+TEST_F(LlamaControllerTest, NonConversationalModeDoesNotBuildHistory) {
+    auto load_result = controller->load_model(params);
+    ASSERT_EQ(load_result, godot::OK);
+    
+    std::string error_msg;
+    params.n_predict = 10;
+    
+    std::string result_1 = controller->start_generation(
+        params, "Say hello", "", "", false,  // is_conversational = false
+        [](const std::string& chunk) {},
+        &error_msg
+    );
+    
+    ASSERT_TRUE(error_msg.empty());
+    ASSERT_TRUE(controller->get_conversation_history().empty());  // No history
+
+    std::string result_2 = controller->start_generation(
+        params, "Say goodbye", "", "", false,
+        [](const std::string& chunk) {},
+        &error_msg
+    );
+    
+    ASSERT_TRUE(error_msg.empty());
+    ASSERT_TRUE(controller->get_conversation_history().empty());  // Still no history
+}
+
+TEST_F(LlamaControllerTest, ConversationalModeBuildHistory) {
+    auto load_result = controller->load_model(params);
+    ASSERT_EQ(load_result, godot::OK);
+
+    std::string error_msg;
+    params.n_predict = 10;
+
+    std::string result_1 = controller->start_generation(
+        params, "Hello", "", "", true,  // is_conversational = true
+        [](const std::string& chunk) {},
+        &error_msg
+    );
+
+    ASSERT_TRUE(error_msg.empty());
+    ASSERT_EQ(controller->get_conversation_history().size(), 2);  // user + assistant
+    ASSERT_EQ(controller->get_conversation_history()[0].role, "user");
+    ASSERT_EQ(controller->get_conversation_history()[0].content, "Hello");
+    ASSERT_EQ(controller->get_conversation_history()[1].role, "assistant");
+
+    std::string result_2 = controller->start_generation(
+        params, "How are you?", "", "", true,
+        [](const std::string& chunk) {},
+        &error_msg
+    );
+
+    ASSERT_TRUE(error_msg.empty());
+    ASSERT_EQ(controller->get_conversation_history().size(), 4);  // 2 exchanges
+}
+
+TEST_F(LlamaControllerTest, InfinitePredictGeneratesUntilEOS) {
+    auto load_result = controller->load_model(params);
+    ASSERT_EQ(load_result, godot::OK);
+
+    std::string error_msg;
+    params.n_predict = -1;  // Infinite
+    params.n_ctx = 128;
+    params.sampling.ignore_eos = false;
+    // Adjust sampling parameters to encourage completion
+    params.sampling.temp = 1.5f;
+    params.sampling.penalty_repeat = 1.0f;
+    params.sampling.top_p = 0.95f;
+
+
+    std::string result = controller->start_generation(
+        params, "Say hello", "", "", false,
+        [](const std::string& chunk) {},
+        &error_msg
+    );
+
+    ASSERT_TRUE(error_msg.empty());
+    ASSERT_FALSE(result.empty());  // Hopefully it generated something
 }


### PR DESCRIPTION
Resolves #63 
Resolves #62 

- Infinite generation actually wouldn't generate anything -- now it will
- `llama_controller` shouldn't touch llama, but it did substantially by applying chat templates. This moves chat templating to the `llama_runner`

## Testing
- Added to the test suite -- have to be cautious about this, as we only have so many free minutes...
- Manually added extension to Godot and ran test suite